### PR TITLE
fixed static innerHeight bug in UseEffectExample

### DIFF
--- a/src/hooks/UseEffectExample.js
+++ b/src/hooks/UseEffectExample.js
@@ -73,7 +73,7 @@ export function Title() {
   });
   const [height, setHeight] = useState(window.innerHeight);
   useEffect(() => {
-    const handleResize = setHeight(window.innerHeight);
+    const handleResize = () => setHeight(window.innerHeight);
     window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('resize', handleResize);


### PR DESCRIPTION
Amazing, amazing work, Adeel, I've been going through all of your medium tutorials -- you're a true inspiration and incredible teacher.  I found a minor bug in the UseEffectExample: the window Height did not change in the new hooks version, so I mirrored line 6 in `UseCustomHooks.js`, i.e., mirroring `useWindowWidth()` with height.  Thanks again!